### PR TITLE
Upgrade to Vert.x 3.8.5 and Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <vertx.platform.version>3.5.4</vertx.platform.version>
+        <vertx.platform.version>3.8.5</vertx.platform.version>
         <aws.sdk.version>1.11.564</aws.sdk.version>
         <nexus.host>default</nexus.host>
-        <mockito.version>2.12.0</mockito.version>
+        <mockito.version>3.2.4</mockito.version>
         <aetherVersion>1.1.0</aetherVersion>
         <mavenVersion>3.6.0</mavenVersion>
         <dependency.check.report.dir>target/dependency-check</dependency.check.report.dir>
@@ -243,10 +243,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>nl.jpoint</groupId>
     <artifactId>vertx-deploy-tools</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.8.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <description>Vert.x application for deploying of other Vert.x applications with support for AWS based

--- a/vertx-deploy-agent/pom.xml
+++ b/vertx-deploy-agent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>nl.jpoint</groupId>
         <artifactId>vertx-deploy-tools</artifactId>
-        <version>3.5.6-SNAPSHOT</version>
+        <version>3.8.5-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.jpoint.vertx-deploy-tools</groupId>

--- a/vertx-deploy-agent/src/test/java/TestRunner.java
+++ b/vertx-deploy-agent/src/test/java/TestRunner.java
@@ -2,7 +2,7 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
-import static io.vertx.core.impl.FileResolver.DISABLE_CP_RESOLVING_PROP_NAME;
+import static io.vertx.core.file.impl.FileResolver.DISABLE_CP_RESOLVING_PROP_NAME;
 import static java.lang.Boolean.TRUE;
 
 public class TestRunner {

--- a/vertx-deploy-maven-plugin/pom.xml
+++ b/vertx-deploy-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>nl.jpoint</groupId>
         <artifactId>vertx-deploy-tools</artifactId>
-        <version>3.5.6-SNAPSHOT</version>
+        <version>3.8.5-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.jpoint.vertx-deploy-tools</groupId>

--- a/vertx-deploy-test-application/pom.xml
+++ b/vertx-deploy-test-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>nl.jpoint</groupId>
         <artifactId>vertx-deploy-tools</artifactId>
-        <version>3.5.6-SNAPSHOT</version>
+        <version>3.8.5-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.jpoint.vertx-deploy-tools</groupId>

--- a/vertx-deploy-test-application/src/test/java/nl/jpoint/vertx/mod/test/TestRunner.java
+++ b/vertx-deploy-test-application/src/test/java/nl/jpoint/vertx/mod/test/TestRunner.java
@@ -2,7 +2,7 @@ package nl.jpoint.vertx.mod.test;
 
 import io.vertx.core.Vertx;
 
-import static io.vertx.core.impl.FileResolver.DISABLE_CP_RESOLVING_PROP_NAME;
+import static io.vertx.core.file.impl.FileResolver.DISABLE_CP_RESOLVING_PROP_NAME;
 import static java.lang.Boolean.TRUE;
 
 public class TestRunner {

--- a/vertx-deploy-test-artifact/pom.xml
+++ b/vertx-deploy-test-artifact/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>nl.jpoint</groupId>
         <artifactId>vertx-deploy-tools</artifactId>
-        <version>3.5.6-SNAPSHOT</version>
+        <version>3.8.5-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.jpoint.vertx-deploy-tools</groupId>

--- a/vertx-deploy-test-config/pom.xml
+++ b/vertx-deploy-test-config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>nl.jpoint</groupId>
         <artifactId>vertx-deploy-tools</artifactId>
-        <version>3.5.6-SNAPSHOT</version>
+        <version>3.8.5-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.jpoint.vertx-deploy-tools</groupId>

--- a/vertx-deploy-test/pom.xml
+++ b/vertx-deploy-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>nl.jpoint</groupId>
         <artifactId>vertx-deploy-tools</artifactId>
-        <version>3.5.6-SNAPSHOT</version>
+        <version>3.8.5-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.jpoint.vertx-deploy-tools</groupId>


### PR DESCRIPTION
- Upgrade to Vert.x 3.8.5 including necessary code changes
- Upgrade to Java 11 including upgrading plugins and dependencies who needed an upgrade for Java 11 