### PR TITLE
Vertx 3.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <vertx.platform.version>3.8.5</vertx.platform.version>
+        <vertx.platform.version>3.9.3</vertx.platform.version>
         <aws.sdk.version>1.11.922</aws.sdk.version>
         <nexus.host>default</nexus.host>
         <mockito.version>3.2.4</mockito.version>

--- a/vertx-deploy-agent/src/main/java/nl/jpoint/vertx/deploy/agent/handler/RestDeployHandler.java
+++ b/vertx-deploy-agent/src/main/java/nl/jpoint/vertx/deploy/agent/handler/RestDeployHandler.java
@@ -23,7 +23,7 @@ import static rx.Observable.just;
 
 public class RestDeployHandler implements Handler<RoutingContext> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(RestDeployModuleHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RestDeployHandler.class);
     private final DefaultDeployService deployService;
     private final Optional<AwsService> awsService;
     private final String authToken;
@@ -201,9 +201,9 @@ public class RestDeployHandler implements Handler<RoutingContext> {
     }
 
     private void respond(DeployRequest deployRequest, HttpServerRequest request) {
-        request.response().setStatusCode(HttpResponseStatus.OK.code());
         awsService.ifPresent(aws -> aws.updateAndGetRequest(DeployState.SUCCESS, deployRequest.getId().toString()));
         if (!request.response().ended() && !deployRequest.withElb() && !deployRequest.withAutoScaling()) {
+            request.response().setStatusCode(HttpResponseStatus.OK.code());
             JsonObject result = new JsonObject();
             result.put(ApplicationDeployState.OK.name(), HttpUtils.toArray(deployService.getDeployedApplicationsSuccess()));
             result.put(ApplicationDeployState.ERROR.name(), HttpUtils.toArray(deployService.getDeployedApplicationsFailed()));

--- a/vertx-deploy-agent/src/main/java/nl/jpoint/vertx/deploy/agent/util/AetherUtil.java
+++ b/vertx-deploy-agent/src/main/java/nl/jpoint/vertx/deploy/agent/util/AetherUtil.java
@@ -98,6 +98,6 @@ public class AetherUtil {
     }
 
     private static RemoteRepository newCentralRepository() {
-        return new RemoteRepository.Builder("central", "default", "http://central.maven.org/maven2/").build();
+        return new RemoteRepository.Builder("central", "default", "https://repo.maven.apache.org/maven2").build();
     }
 }


### PR DESCRIPTION
Vert.x 3.9.3 introduces a more strict check on whether the http response / header has already been written, in the HttpServerResponseImpl class.
See:

https://github.com/eclipse-vertx/vert.x/blob/3.9.3/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
vs
https://github.com/eclipse-vertx/vert.x/blob/3.9.2/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java

Since version vert.x 3.9.3 the way methods like #setStatusCode and #setStatusMessage are implemented has changed.

  ```
@Override
  public HttpServerResponse setStatusCode(int statusCode) {
    synchronized (conn) {
      checkHeadWritten();
      status = statusMessage != null ? new HttpResponseStatus(statusCode, statusMessage) : HttpResponseStatus.valueOf(statusCode);
    }
    return this;
  }
```

vs 

 ```
@Override
  public HttpServerResponse setStatusCode(int statusCode) {
    status = statusMessage != null ? new HttpResponseStatus(statusCode, statusMessage) : HttpResponseStatus.valueOf(statusCode);
    return this;
  }
```

Notice the synchronized(conn) and checkHeadWritter().

This results in an issue with how this is used in the `RestDeployHandler` where we should only set the statusCode on the response when the response has not already been ended.

Besides this issue I also ran into an issue with the link to the maven central repo.