### PR TITLE
Vertx 3.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <vertx.platform.version>3.9.5</vertx.platform.version>
-        <aws.sdk.version>1.11.922</aws.sdk.version>
+        <aws.sdk.version>1.11.937</aws.sdk.version>
         <nexus.host>default</nexus.host>
         <mockito.version>3.2.4</mockito.version>
         <aetherVersion>1.1.0</aetherVersion>
@@ -53,12 +53,12 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.3</version>
+                <version>4.5.13</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.8</version>
+                <version>4.4.14</version>
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
@@ -131,7 +131,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.19</version>
+                <version>1.20</version>
             </dependency>
 
             <dependency>
@@ -177,7 +177,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.10.5.1</version>
+                <version>2.11.3</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <vertx.platform.version>3.9.3</vertx.platform.version>
+        <vertx.platform.version>3.9.5</vertx.platform.version>
         <aws.sdk.version>1.11.922</aws.sdk.version>
         <nexus.host>default</nexus.host>
         <mockito.version>3.2.4</mockito.version>


### PR DESCRIPTION
update vertx to version 3.9.5
vert 3.9.5 uses a more recent version of jackson (2.11.3)
newest version of the awssdk (1.11.937) expects a newer version of httpclient (4.5.13) (and httpcore, 4.4.14)